### PR TITLE
Change `sql/table.Table.IndexRecord` signature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sfomuseum/go-database
 
-go 1.23.3
+go 1.24.0

--- a/sql/table.go
+++ b/sql/table.go
@@ -21,8 +21,7 @@ type Table interface {
 	Name() string
 	Schema(*sql.DB) (string, error)
 	InitializeTable(context.Context, *sql.DB) error
-	// IndexRecord(context.Context, *sql.DB, interface{}) error
-	IndexRecord(context.Context, *sql.Tx, interface{}) error
+	IndexRecord(context.Context, *sql.DB, *sql.Tx, interface{}) error
 }
 
 func HasTable(ctx context.Context, db *sql.DB, table_name string) (bool, error) {
@@ -83,7 +82,7 @@ func IndexRecord(ctx context.Context, db *sql.DB, r interface{}, tables ...Table
 
 	for _, t := range tables {
 
-		err := t.IndexRecord(ctx, tx, r)
+		err := t.IndexRecord(ctx, db, tx, r)
 
 		if err != nil {
 			tx.Rollback()


### PR DESCRIPTION
* Change `sql/table.Table.IndexRecord` signature to take `db.Tx` parameter
* Add `sql/table.IndexRecord` method to hide transaction stuff
* This release is NOT backwards compatible